### PR TITLE
This PR introduces unit tests to ensure validation logic for the CreateUserCommand is working as expected.

### DIFF
--- a/RO.DevTest.Tests/Unit/Application/Features/User/Commands/CreateUserCommandHandlerTests.cs
+++ b/RO.DevTest.Tests/Unit/Application/Features/User/Commands/CreateUserCommandHandlerTests.cs
@@ -1,24 +1,31 @@
 ﻿using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
 using Moq;
 using RO.DevTest.Application.Contracts.Infrastructure;
 using RO.DevTest.Application.Features.User.Commands.CreateUserCommand;
+using RO.DevTest.Domain.Enums;
 using RO.DevTest.Domain.Exception;
+using AppUser = RO.DevTest.Domain.Entities.User;
 
 namespace RO.DevTest.Tests.Unit.Application.Features.User.Commands;
 
-public class CreateUserCommandHandlerTests {
+public class CreateUserCommandHandlerTests
+{
     private readonly Mock<IIdentityAbstractor> _identityAbstractorMock = new();
     private readonly CreateUserCommandHandler _sut;
 
-    public CreateUserCommandHandlerTests() { 
-        _sut = new (_identityAbstractorMock.Object);
+    public CreateUserCommandHandlerTests()
+    {
+        _sut = new(_identityAbstractorMock.Object);
     }
 
     [Fact(DisplayName = "Given invalid email should throw a BadRequestException")]
-    public void Handle_WhenEmailIsNullOrEmpty_ShouldRaiseABadRequestExcpetion() {
+    public void Handle_WhenEmailIsNullOrEmpty_ShouldRaiseABadRequestExcpetion()
+    {
         // Arrange
         string email = string.Empty, password = Guid.NewGuid().ToString();
-        CreateUserCommand command = new() {
+        CreateUserCommand command = new()
+        {
             Email = email,
             UserName = "user_test",
             Password = password,
@@ -34,12 +41,14 @@ public class CreateUserCommandHandlerTests {
     }
 
     [Fact(DisplayName = "Given passwords not matching should throw a BadRequestException")]
-    public void Handle_WhenPasswordDoesntMatchPasswordConfirmation_ShouldRaiseABadRequestException() {
+    public void Handle_WhenPasswordDoesntMatchPasswordConfirmation_ShouldRaiseABadRequestException()
+    {
         // Arrange
         string email = "mytestemail@someprovider.com"
             , password = Guid.NewGuid().ToString()
             , passwordConfirmation = Guid.NewGuid().ToString();
-        CreateUserCommand command = new() {
+        CreateUserCommand command = new()
+        {
             Email = email,
             UserName = "user_test",
             Password = password,
@@ -52,5 +61,91 @@ public class CreateUserCommandHandlerTests {
 
         // Assert
         action.Should().ThrowAsync<BadRequestException>();
+    }
+
+    [Fact(DisplayName = "Given successful user creation should return CreateUserResult")]
+    public async Task Handle_WhenDataIsValid_ShouldReturnCreateUserResult()
+    {
+        // Arrange
+        var password = "StrongPassword123!";
+        var user = new AppUser { Email = "valid@test.com", UserName = "user_test", Name = "User" };
+
+        CreateUserCommand command = new()
+        {
+            Email = user.Email,
+            UserName = user.UserName,
+            Password = password,
+            PasswordConfirmation = password,
+            Name = user.Name,
+            Role = UserRoles.Admin
+        };
+
+        _identityAbstractorMock.Setup(x => x.CreateUserAsync(It.IsAny<AppUser>(), password))
+            .ReturnsAsync(IdentityResult.Success);
+
+        _identityAbstractorMock.Setup(x => x.AddToRoleAsync(It.IsAny<AppUser>(), UserRoles.Admin))
+            .ReturnsAsync(IdentityResult.Success);
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Email.Should().Be(command.Email);
+        result.UserName.Should().Be(command.UserName);
+        result.Name.Should().Be(command.Name);
+    }
+
+    [Fact(DisplayName = "Given failed user creation should throw BadRequestException")]
+    public async Task Handle_WhenUserCreationFails_ShouldRaiseBadRequestException()
+    {
+        // Arrange
+        var password = "StrongPassword123!";
+        CreateUserCommand command = new()
+        {
+            Email = "test@domain.com",
+            UserName = "testuser",
+            Password = password,
+            PasswordConfirmation = password,
+            Name = "Test",
+            Role = UserRoles.Admin
+        };
+
+        _identityAbstractorMock.Setup(x => x.CreateUserAsync(It.IsAny<AppUser>(), password))
+            .ReturnsAsync(IdentityResult.Failed());
+
+        // Act
+        Func<Task> act = async () => await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<BadRequestException>();
+    }
+
+    [Fact(DisplayName = "Given role assignment fails should throw BadRequestException")]
+    public async Task Handle_WhenRoleAssignmentFails_ShouldRaiseBadRequestException()
+    {
+        // Arrange
+        var password = "StrongPassword123!";
+        CreateUserCommand command = new()
+        {
+            Email = "test@domain.com",
+            UserName = "testuser",
+            Password = password,
+            PasswordConfirmation = password,
+            Name = "Test",
+            Role = UserRoles.Admin
+        };
+
+        _identityAbstractorMock.Setup(x => x.CreateUserAsync(It.IsAny<AppUser>(), password))
+            .ReturnsAsync(IdentityResult.Success);
+
+        _identityAbstractorMock.Setup(x => x.AddToRoleAsync(It.IsAny<AppUser>(), UserRoles.Admin))
+            .ReturnsAsync(IdentityResult.Failed());
+
+        // Act
+        Func<Task> act = async () => await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<BadRequestException>();
     }
 }

--- a/RO.DevTest.Tests/Unit/Application/Features/User/Validators/CreateUserCommandValidatorTests.cs
+++ b/RO.DevTest.Tests/Unit/Application/Features/User/Validators/CreateUserCommandValidatorTests.cs
@@ -1,0 +1,80 @@
+﻿using FluentValidation.TestHelper;
+using RO.DevTest.Application.Features.User.Commands.CreateUserCommand;
+
+namespace RO.DevTest.Tests.Unit.Application.Features.User.Validators;
+
+public class CreateUserCommandValidatorTests
+{
+    private readonly CreateUserCommandValidator _validator;
+
+    public CreateUserCommandValidatorTests()
+    {
+        _validator = new CreateUserCommandValidator();
+    }
+
+    [Fact(DisplayName = "Should have validation error when email is empty")]
+    public void Should_HaveError_WhenEmailIsEmpty()
+    {
+        var command = new CreateUserCommand { Email = string.Empty };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Email);
+    }
+
+    [Fact(DisplayName = "Should have validation error when email is invalid")]
+    public void Should_HaveError_WhenEmailIsInvalid()
+    {
+        var command = new CreateUserCommand { Email = "invalid-email" };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Email);
+    }
+
+    [Fact(DisplayName = "Should have validation error when password is too short")]
+    public void Should_HaveError_WhenPasswordIsShort()
+    {
+        var command = new CreateUserCommand { Password = "123" };
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Password);
+    }
+
+    [Fact(DisplayName = "Should pass when PasswordConfirmation matches Password (with Matches)")]
+    public void Should_NotHaveValidationError_WhenPasswordConfirmationMatches()
+    {
+        var command = new CreateUserCommand
+        {
+            Email = "user@email.com",
+            Password = "MyPassword123",
+            PasswordConfirmation = "MyPassword123"
+        };
+
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(x => x.PasswordConfirmation);
+    }
+
+    [Fact(DisplayName = "Should fail when PasswordConfirmation does not match Password (with Matches)")]
+    public void Should_HaveValidationError_WhenPasswordConfirmationIsDifferent()
+    {
+        var command = new CreateUserCommand
+        {
+            Email = "user@email.com",
+            Password = "MyPassword123",
+            PasswordConfirmation = "Different123"
+        };
+
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.PasswordConfirmation);
+    }
+
+    [Fact(DisplayName = "Should pass when all fields are valid")]
+    public void Should_NotHaveError_WhenCommandIsValid()
+    {
+        var command = new CreateUserCommand
+        {
+            Email = "valid@email.com",
+            Password = "Password123",
+            PasswordConfirmation = "Password123"
+        };
+
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}


### PR DESCRIPTION
- Invalid email and short password cases
- Password confirmation mismatch (using .Matches)
- Valid command scenario